### PR TITLE
Strip READ_PHONE_STATE from merged manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
 	<!-- Prevent dependencies from adding these permissions -->
 	<uses-permission android:name="android.permission.INTERNET" tools:node="remove"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" tools:node="remove"/>
+	<uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
     <application
             android:name=".SnapSafeApplication"


### PR DESCRIPTION
## Summary
- A transitive dependency (likely ML Kit `com.google.mlkit:face-detection` in the `full` flavor, which pulls Play Services Basement) was injecting `android.permission.READ_PHONE_STATE` into the merged manifest.
- The app doesn't use telephony state — strip it with `tools:node="remove"`, matching the existing pattern already in place for `INTERNET` and `ACCESS_NETWORK_STATE`.

## Notes
- Source manifests (`main`, `oss`, `full`) never declared this permission; only manifest merging from a dependency was adding it.
- I wasn't able to confirm via a local build in this environment (Google's Maven repo isn't reachable here), so please verify locally by checking `app/build/outputs/apk/full/debug/` with `aapt dump permissions` — or inspect `app/build/intermediates/merged_manifests/fullDebug/AndroidManifest.xml`.

## Test plan
- [ ] `./gradlew assembleFullDebug` succeeds
- [ ] `aapt dump permissions app/build/outputs/apk/full/debug/app-full-debug.apk` no longer lists `READ_PHONE_STATE`
- [ ] Same check for `assembleOssDebug` (should already be clean, but verify nothing regressed)
- [ ] Smoke test the app: camera capture, face-detection feature (full flavor) still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGZwrUZfoLN5NQHDfs3DDt)_